### PR TITLE
`camel case` problem when `xo` is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ rainbow
 	.reset() //we do not want black and white anymore - note it does not reset options only colors
 	.skip(rainbow._backgrounds) //skips backgrounds
 	.add('bgBlue bgMagenta bgCyan') //this will keep order when rainbowified
-	.options({color_space: true, gap: 3}) //this will force color spaces and change color every 3 characters
+	.options({colorSpace: true, gap: 3}) //this will force color spaces and change color every 3 characters
 
 	console.log(rainbow.bg('         '))
 	console.log(rainbow.bg('123456789'))
@@ -63,7 +63,7 @@ That outputs:
 - add(colors)         do not skip colors         
 - skip(colors)        skip colors         
 - reset()             reset colors (skips ['black', 'white', 'bgBlack', 'bgWhite'])         
-- options({})         set options - options are (bool) color_space, (int) gap
+- options({})         set options - options are (bool) colorSpace, (int) gap
 
 # TODO
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var Pony = function() {
   this._next = 0
   this._prev = -1
 
-  this.options = {color_space: false, gap: 1, space_color: null}
+  this.options = {colorSpace: false, gap: 1, spaceColor: null}
 
   var self = this
 
@@ -161,7 +161,7 @@ Pony.prototype = {
     }
 
   },
-  colorSpace: function(s, color) {
+  colSpaces: function(s, color) {
     if(!this.allowed(color))
       throw new Error('Color '+ colors[l] +' is not recognized')
 
@@ -178,12 +178,12 @@ Pony.prototype = {
 
       if(s == '\n') {
         output += s
-      } else if(s == ' ' && !this.options.color_space) {
+      } else if(s == ' ' && !this.options.colorSpace) {
         output += s
       } else {
 
-        if(s == ' ' && this.options.space_color != null)
-          output += this.colorSpace(s, this.options.space_color)
+        if(s == ' ' && this.options.spaceColor != null)
+          output += this.colSpaces(s, this.options.spaceColor)
         else
           output += this._current_gap == gap ? this.nextColor(s, colors) : this.currentColor(s, colors)
       }

--- a/test/test.js
+++ b/test/test.js
@@ -50,18 +50,18 @@ describe('PONY', function() {
 	})
 
 	it("should color spaces with 3 gap - it's a flag \\o/", function() {
-		rainbow.options({color_space: true, gap: 3})
+		rainbow.options({colorSpace: true, gap: 3})
 		console.log(rainbow.bg('         '))
 		console.log(rainbow.bg('         '))
 	})
 
 	it('should color characters with a 3 gap', function() {
-		rainbow.reset().options({color_space: false})
+		rainbow.reset().options({colorSpace: false})
 
 		console.log(rainbow.r(' testtest    test'))
 		console.log(rainbow.r('Some three caracters gap'))
 	
-		rainbow.options({color_space: true}).reset().skip(rainbow._backgrounds).add('bgBlue bgMagenta bgCyan')
+		rainbow.options({colorSpace: true}).reset().skip(rainbow._backgrounds).add('bgBlue bgMagenta bgCyan')
 
 		console.log(rainbow.bg('         '))
 		console.log(rainbow.bg('123456789'))
@@ -70,7 +70,7 @@ describe('PONY', function() {
 	})
 
 	it('should color spaces with a blue bg', function() {
-		rainbow.reset().options({gap: 1, color_space: true, space_color: 'bgBlue'}).skip('bgBlue')
+		rainbow.reset().options({gap: 1, colorSpace: true, spaceColor: 'bgBlue'}).skip('bgBlue')
 
 		console.log(rainbow.bg('text  with  some  space'))
 


### PR DESCRIPTION
`npm test` will keep throwing `errror` if someone is using [xo](https://github.com/sindresorhus/xo) as a linter.

![screenshot from 2016-06-18 01 12 00](https://cloud.githubusercontent.com/assets/9411252/16162632/38951c34-34f2-11e6-9556-6b50b734ca85.png)

To prevent it from above problem, I've done some changes and now `tests` are running throwing any `error`
